### PR TITLE
fix: run consecutive async operation with nuxt context

### DIFF
--- a/composables/useCart.ts
+++ b/composables/useCart.ts
@@ -66,7 +66,7 @@ export const useCart = () => {
   async function getCart() {
     const cartId = useCookie("cartId");
     if (!cartId.value) {
-      const { data } = await useAsyncGql("createCart"); 
+      const { data } = await useAsyncGql("createCart");
       cartId.value = data.value.cartCreate?.cart?.id;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Description
Hey :wave: here's a small fix for the `getCart` function. If we don't have any cartId, the `useAsyncGql("getCart")` will fail because it will loose the nuxt context.
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->


## Checklist:
<!--- Put an `x` in all the boxes that apply. -->
<!--- If your change requires a documentation PR, please link it appropriately -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes (if not applicable, please state why)
